### PR TITLE
Rollback dockerfile: uses python 3.10+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM alpine AS download
-RUN apk add --update-cache curl
+FROM python:alpine AS download
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update-cache \
+    bash \
+    curl
+
 WORKDIR /downloads
+
 RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
 RUN chmod +x kubectl
-
-FROM gcr.io/distroless/python3
-COPY --from=download /downloads/kubectl /usr/local/bin/kubectl
+RUN cp /downloads/kubectl /usr/local/bin/kubectl
 WORKDIR /app
 COPY . /app
-ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
distroless is using python 3.9 and it's incompatible.